### PR TITLE
fix: remove console.logs and secure admin auth server-side (#134, #135)

### DIFF
--- a/backend/app/api/v1/endpoints/users.py
+++ b/backend/app/api/v1/endpoints/users.py
@@ -2,7 +2,8 @@ from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
 from sqlalchemy.orm import Session
 from app.core.database import get_db
 from app.services.user_service import UserService
-from app.schemas.user import UserCreate, UserResponse, UserUpdate, UserProfileUpdate
+from app.schemas.user import UserCreate, UserResponse, UserUpdate, UserProfileUpdate, MeResponse
+from app.core.config import settings
 from app.schemas.base_schema import ApiResponse
 from app.core.security import get_current_user
 from app.models.user import User
@@ -38,10 +39,12 @@ def index(
     users = user_service.get_all()
     return ApiResponse(data=[UserResponse.model_validate(u) for u in users])
 
-@router.get("/me", response_model=ApiResponse[UserResponse])
+@router.get("/me", response_model=ApiResponse[MeResponse])
 def get_me(current_user: User = Depends(get_current_user)):
     """Get details of the logged-in user (Protected Route)"""
-    return ApiResponse(data=UserResponse.model_validate(current_user))
+    is_admin = current_user.email.strip().lower() in settings.ADMIN_EMAILS
+    me = MeResponse(**UserResponse.model_validate(current_user).model_dump(), is_admin=is_admin)
+    return ApiResponse(data=me)
 
 @router.get("/{user_id}", response_model=ApiResponse[UserResponse])
 @log_exceptions("GET /users/{user_id}")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -32,7 +32,10 @@ class Settings:
     REFRESH_TOKEN_EXPIRE_DAYS: int = 7
     ENVIRONMENT: str = "local"
     POPULAR_BOOKS_CACHE_TTL: int = int(os.getenv("POPULAR_BOOKS_CACHE_TTL", 3600))  # 1 hour default
-    ADMIN_EMAILS: list[str] = ["admin@sonic.com"]
+    @property
+    def ADMIN_EMAILS(self) -> list[str]:
+        raw = os.getenv("ADMIN_EMAILS", "admin@sonic.com")
+        return [e.strip().lower() for e in raw.split(",") if e.strip()]
     REDIS_URL: str = os.getenv("REDIS_URL", "redis://redis:6379/0")
     SEARCH_RATE_LIMIT: int = int(os.getenv("SEARCH_RATE_LIMIT", 30))
     SEARCH_RATE_LIMIT_WINDOW: int = int(os.getenv("SEARCH_RATE_LIMIT_WINDOW", 60))

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -18,6 +18,9 @@ class UserResponse(UserBase):
 
     model_config = ConfigDict(from_attributes=True)
 
+class MeResponse(UserResponse):
+    is_admin: bool
+
 class UserProfileUpdate(BaseModel):
     name: Optional[str] = None
     profile_picture: Optional[str] = None

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -4,6 +4,7 @@ from faker import Faker
 from email_validator import validate_email, EmailNotValidError
 from app.core.database import SessionLocal
 from app.models.user import User
+from app.core.config import settings
 import traceback
 
 fake = Faker()
@@ -73,3 +74,28 @@ def test_get_users():
     response = client.get("/users", cookies=cookies)
     assert response.status_code == 200
     assert isinstance(response.json()["data"], list)
+
+
+def test_me_is_admin_false_for_normal_user():
+    """Normal users should have is_admin: false on /users/me."""
+    cookies, _ = create_user_and_get_cookies()
+    response = client.get("/users/me", cookies=cookies)
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert "is_admin" in data
+    assert data["is_admin"] is False
+
+
+def test_me_is_admin_true_when_email_in_admin_emails(monkeypatch):
+    """Users whose email appears in ADMIN_EMAILS should have is_admin: true on /users/me."""
+    cookies, new_user = create_user_and_get_cookies()
+
+    # Patch settings so the freshly-created user is considered an admin.
+    admin_email = new_user["email"].strip().lower()
+    monkeypatch.setattr(type(settings), "ADMIN_EMAILS", property(lambda self: [admin_email]))
+
+    response = client.get("/users/me", cookies=cookies)
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert "is_admin" in data
+    assert data["is_admin"] is True

--- a/frontend/src/app/(protected)/admin/admin-dashboard.tsx
+++ b/frontend/src/app/(protected)/admin/admin-dashboard.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useAuthStore } from "@/store/useAuthStore";
+import { getStats } from "@/services/adminService";
+import type { AdminStats } from "@/interfaces/admin";
+import { StatsCards } from "@/components/admin/stats-cards";
+import { AdminUsersTable } from "@/components/admin/users-table";
+import { AdminReviewsTable } from "@/components/admin/reviews-table";
+import { AdminUserBooksTable } from "@/components/admin/user-books-table";
+
+const TABS = [
+  { key: "users", label: "Users" },
+  { key: "reviews", label: "Reviews" },
+  { key: "user-books", label: "User Books" },
+] as const;
+
+type TabKey = (typeof TABS)[number]["key"];
+
+function AdminDashboardContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const user = useAuthStore((state) => state.user);
+  const [stats, setStats] = useState<AdminStats | null>(null);
+
+  const activeTab = (searchParams.get("tab") as TabKey) || "users";
+
+  useEffect(() => {
+    if (user && !user.is_admin) {
+      router.replace("/books");
+    }
+  }, [user, router]);
+
+  useEffect(() => {
+    getStats().then((data) => {
+      if (data) setStats(data);
+    });
+  }, []);
+
+  const setTab = (tab: TabKey) => {
+    router.push(`/admin?tab=${tab}`);
+  };
+
+  if (!user || !user.is_admin) {
+    return null;
+  }
+
+  return (
+    <div className="p-6 max-w-7xl mx-auto">
+      <h1 className="text-2xl font-bold text-white mb-6">Admin Dashboard</h1>
+
+      <StatsCards stats={stats} />
+
+      <div className="flex border-b border-blue-600 mb-6">
+        {TABS.map(({ key, label }) => (
+          <button
+            key={key}
+            onClick={() => setTab(key)}
+            className={`px-6 py-3 text-sm font-medium transition-colors ${
+              activeTab === key
+                ? "text-orange-300 border-b-2 border-orange-300"
+                : "text-blue-400 hover:text-white"
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === "users" && <AdminUsersTable />}
+      {activeTab === "reviews" && <AdminReviewsTable />}
+      {activeTab === "user-books" && <AdminUserBooksTable />}
+    </div>
+  );
+}
+
+export default function AdminDashboard() {
+  return (
+    <Suspense>
+      <AdminDashboardContent />
+    </Suspense>
+  );
+}

--- a/frontend/src/app/(protected)/admin/page.tsx
+++ b/frontend/src/app/(protected)/admin/page.tsx
@@ -1,85 +1,40 @@
-"use client";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { getBackendUrl } from "@/lib/api-client";
+import type User from "@/interfaces/user";
+import AdminDashboard from "./admin-dashboard";
 
-import { Suspense, useEffect, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
-import { useAuthStore } from "@/store/useAuthStore";
-import { ADMIN_EMAILS } from "@/config";
-import { getStats } from "@/services/adminService";
-import type { AdminStats } from "@/interfaces/admin";
-import { StatsCards } from "@/components/admin/stats-cards";
-import { AdminUsersTable } from "@/components/admin/users-table";
-import { AdminReviewsTable } from "@/components/admin/reviews-table";
-import { AdminUserBooksTable } from "@/components/admin/user-books-table";
-
-const TABS = [
-  { key: "users", label: "Users" },
-  { key: "reviews", label: "Reviews" },
-  { key: "user-books", label: "User Books" },
-] as const;
-
-type TabKey = (typeof TABS)[number]["key"];
-
-function AdminDashboardContent() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const user = useAuthStore((state) => state.user);
-  const [stats, setStats] = useState<AdminStats | null>(null);
-
-  const activeTab = (searchParams.get("tab") as TabKey) || "users";
-
-  useEffect(() => {
-    if (user && !ADMIN_EMAILS.includes(user.email)) {
-      router.replace("/books");
-    }
-  }, [user, router]);
-
-  useEffect(() => {
-    getStats().then((data) => {
-      if (data) setStats(data);
-    });
-  }, []);
-
-  const setTab = (tab: TabKey) => {
-    router.push(`/admin?tab=${tab}`);
-  };
-
-  if (!user || !ADMIN_EMAILS.includes(user.email)) {
-    return null;
-  }
-
-  return (
-    <div className="p-6 max-w-7xl mx-auto">
-      <h1 className="text-2xl font-bold text-white mb-6">Admin Dashboard</h1>
-
-      <StatsCards stats={stats} />
-
-      <div className="flex border-b border-blue-600 mb-6">
-        {TABS.map(({ key, label }) => (
-          <button
-            key={key}
-            onClick={() => setTab(key)}
-            className={`px-6 py-3 text-sm font-medium transition-colors ${
-              activeTab === key
-                ? "text-orange-300 border-b-2 border-orange-300"
-                : "text-blue-400 hover:text-white"
-            }`}
-          >
-            {label}
-          </button>
-        ))}
-      </div>
-
-      {activeTab === "users" && <AdminUsersTable />}
-      {activeTab === "reviews" && <AdminReviewsTable />}
-      {activeTab === "user-books" && <AdminUserBooksTable />}
-    </div>
-  );
+interface ApiResponse<T> {
+  data: T;
 }
 
-export default function AdminDashboard() {
-  return (
-    <Suspense>
-      <AdminDashboardContent />
-    </Suspense>
-  );
+export default async function AdminPage() {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("access_token")?.value ?? "";
+
+  let isAdmin = false;
+
+  try {
+    const res = await fetch(`${getBackendUrl()}/users/me`, {
+      headers: {
+        Cookie: `access_token=${accessToken}`,
+      },
+      cache: "no-store",
+    });
+
+    if (!res.ok) {
+      redirect("/login");
+    }
+
+    const { data: user }: ApiResponse<User> = await res.json();
+    isAdmin = user.is_admin === true;
+  } catch {
+    redirect("/login");
+  }
+
+  if (!isAdmin) {
+    redirect("/books");
+  }
+
+  return <AdminDashboard />;
 }

--- a/frontend/src/components/navbar.tsx
+++ b/frontend/src/components/navbar.tsx
@@ -9,7 +9,6 @@ import { Menu, Search } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useSearchBookStore } from "@/store/useSearchBookStore";
 import { toast } from "sonner";
-import { ADMIN_EMAILS } from "@/config";
 
 export default function NavBar() {
   const [dropdownOpen, setDropdownOpen] = useState(false);
@@ -118,7 +117,7 @@ export default function NavBar() {
 
       {/* Right-aligned Navigation Links and User Menu */}
       <div className="flex h-full">
-        {user && ADMIN_EMAILS.includes(user.email) && (
+        {user && user.is_admin && (
           <Link
             href="/admin"
             className="flex items-center justify-center h-full px-4 hover:bg-[#004aad] transition-all duration-500 ease-in-out text-orange-300 font-medium"

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,1 +1,0 @@
-export const ADMIN_EMAILS = ["admin@sonic.com"];

--- a/frontend/src/interfaces/user.ts
+++ b/frontend/src/interfaces/user.ts
@@ -3,4 +3,5 @@ export default interface User {
   name: string;
   email: string;
   profile_picture?: string;
+  is_admin: boolean;
 }

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -3,6 +3,7 @@ export interface User {
   name: string;
   email: string;
   profile_picture?: string;
+  is_admin: boolean;
 }
 
 export interface UserProfile extends User {


### PR DESCRIPTION
## Summary

- **fix #135** — Remove all `console.log` calls from frontend source files (`books/page.tsx`, `external/[externalId]/page.tsx`, `BookRecommendationGraph.tsx`) and add a `no-console` ESLint rule to `eslint.config.mjs` to prevent regressions.
- **fix #134** — Harden admin authorization by moving the check to the server:
  - **Backend**: `ADMIN_EMAILS` is now a computed property on `Settings` sourced from an env var (comma-separated), so the list never ships to the client. New `MeResponse` schema adds `is_admin: bool` computed at request time. `/users/me` returns `is_admin`. Two new pytest tests cover the `false` (normal user) and `true` (email in `ADMIN_EMAILS`) cases.
  - **Frontend**: Deleted `frontend/src/config.ts` — `ADMIN_EMAILS` no longer exists in the client bundle. Added `is_admin: boolean` to `User` interfaces/types. Navbar reads `user.is_admin` instead of `ADMIN_EMAILS.includes()`. Admin page converted to an async server component that calls `/users/me` server-side and redirects to `/books` (or `/login`) before any HTML is rendered; client-side tab/table logic extracted to `admin-dashboard.tsx`.

## Test plan

- [ ] `pytest backend/tests/test_users.py` — both new `is_admin` tests pass
- [ ] `npm run lint` in `frontend/` — no `no-console` violations
- [ ] Log in as a non-admin user and confirm the Admin link is absent in the navbar and that navigating to `/admin` redirects to `/books`
- [ ] Log in as an admin (email in `ADMIN_EMAILS` env var) and confirm the Admin link appears and `/admin` renders the dashboard
- [ ] Confirm `ADMIN_EMAILS` does not appear anywhere in the client-side JS bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)