### PR TITLE
fix: replace unsafe tab cast with type guard, add invalid tab error state

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -30,6 +30,7 @@ services:
       MAIL_FROM: noreply@example.com
       MAIL_DISABLED: "true"
       TESTING: "true"
+      ADMIN_EMAILS: admin@e2etest.example.com
     ports:
       - "8001:8000"  # Different port to avoid conflict with dev backend
     mem_limit: 2048m

--- a/frontend/e2e/admin.setup.ts
+++ b/frontend/e2e/admin.setup.ts
@@ -1,0 +1,19 @@
+import { test as setup, expect } from '@playwright/test';
+import { adminUser } from './fixtures';
+import path from 'path';
+import fs from 'fs';
+
+const authFile = path.join(__dirname, '.auth/admin.json');
+
+setup.beforeAll(() => {
+  fs.mkdirSync(path.dirname(authFile), { recursive: true });
+});
+
+setup('authenticate as admin', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill(adminUser.email);
+  await page.getByLabel('Password').fill(adminUser.password);
+  await page.getByRole('button', { name: 'Sign In' }).click();
+  await expect(page).toHaveURL(/.*\/books/, { timeout: 15000 });
+  await page.context().storageState({ path: authFile });
+});

--- a/frontend/e2e/admin/invalid-tab.spec.ts
+++ b/frontend/e2e/admin/invalid-tab.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Admin dashboard tab validation', () => {
+  test('should show error for invalid tab param', async ({ page }) => {
+    await page.goto('/admin?tab=hax');
+
+    await expect(page.getByText('Invalid tab: hax')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('button', { name: 'Go to dashboard' })).toBeVisible();
+  });
+
+  test('should reset to default when clicking Go to dashboard', async ({ page }) => {
+    await page.goto('/admin?tab=hax');
+
+    await expect(page.getByText('Invalid tab: hax')).toBeVisible({ timeout: 10000 });
+    await page.getByRole('button', { name: 'Go to dashboard' }).click();
+
+    await expect(page).toHaveURL(/\/admin$/, { timeout: 10000 });
+    await expect(page.getByText('Invalid tab: hax')).not.toBeVisible();
+  });
+
+  test('should render users table for valid tab', async ({ page }) => {
+    await page.goto('/admin?tab=users');
+
+    await expect(page.getByText('Invalid tab:')).not.toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Admin Dashboard' })).toBeVisible({ timeout: 10000 });
+  });
+
+  test('should render reviews table for valid reviews tab', async ({ page }) => {
+    await page.goto('/admin?tab=reviews');
+
+    await expect(page.getByText('Invalid tab:')).not.toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Admin Dashboard' })).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -32,5 +32,14 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
       testMatch: '**/auth/**/*.spec.ts',
     },
+    {
+      name: 'admin',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'e2e/.auth/admin.json',
+      },
+      dependencies: ['setup'],
+      testMatch: '**/admin/**/*.spec.ts',
+    },
   ],
 });

--- a/frontend/src/app/(protected)/admin/admin-dashboard.tsx
+++ b/frontend/src/app/(protected)/admin/admin-dashboard.tsx
@@ -24,7 +24,13 @@ function AdminDashboardContent() {
   const user = useAuthStore((state) => state.user);
   const [stats, setStats] = useState<AdminStats | null>(null);
 
-  const activeTab = (searchParams.get("tab") as TabKey) || "users";
+  const rawTab = searchParams.get("tab");
+  const VALID_TABS = TABS.map((t) => t.key);
+  const isValidTab = (v: string): v is TabKey =>
+    (VALID_TABS as string[]).includes(v);
+
+  const isInvalidTab = rawTab !== null && !isValidTab(rawTab);
+  const activeTab: TabKey = rawTab && isValidTab(rawTab) ? rawTab : "users";
 
   useEffect(() => {
     if (user && !user.is_admin) {
@@ -68,9 +74,22 @@ function AdminDashboardContent() {
         ))}
       </div>
 
-      {activeTab === "users" && <AdminUsersTable />}
-      {activeTab === "reviews" && <AdminReviewsTable />}
-      {activeTab === "user-books" && <AdminUserBooksTable />}
+      {isInvalidTab && (
+        <div className="flex flex-col items-start gap-4 py-8">
+          <p className="text-orange-300 text-sm font-medium">
+            Invalid tab: {rawTab}
+          </p>
+          <button
+            onClick={() => router.push("/admin")}
+            className="text-blue-400 hover:text-white text-sm underline transition-colors"
+          >
+            Go to dashboard
+          </button>
+        </div>
+      )}
+      {!isInvalidTab && activeTab === "users" && <AdminUsersTable />}
+      {!isInvalidTab && activeTab === "reviews" && <AdminReviewsTable />}
+      {!isInvalidTab && activeTab === "user-books" && <AdminUserBooksTable />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Replaced unsafe `as TabKey` cast on the `?tab=` URL param in `admin-dashboard.tsx` with a proper `isValidTab` type guard, eliminating a silent runtime risk where any arbitrary string was accepted as a valid tab key
- Added `isInvalidTab` flag that renders an inline error message ("Invalid tab: {value}") and a reset button (`router.push("/admin")`) when the URL contains an unrecognised tab value
- Added `frontend/e2e/admin/invalid-tab.spec.ts` with Playwright e2e tests covering the invalid tab error state and reset button behaviour
- Added `frontend/e2e/admin.setup.ts` for admin auth setup and registered a new `admin` Playwright project in `playwright.config.ts` that depends on the existing `setup` project
- Added `ADMIN_EMAILS` env var to the test backend service in `docker-compose.test.yml` so the admin account is recognised in the isolated test environment

Closes #145

## Test plan

- [ ] Navigate to `/admin?tab=nonexistent` — confirm "Invalid tab: nonexistent" message and reset button are rendered
- [ ] Click the reset button — confirm redirect to `/admin` (defaults to `users` tab)
- [ ] Navigate to `/admin?tab=users`, `/admin?tab=reviews`, `/admin?tab=user-books` — confirm all valid tabs still render their tables normally
- [ ] `npm run lint` passes with no new ESLint errors
- [ ] `npx tsc --noEmit` passes clean
- [ ] `next build` completes without errors
- [ ] Playwright e2e suite (`admin` project) passes: `npx playwright test --project=admin`
- [ ] 89 backend tests continue to pass (`pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)