### PR TITLE
fix(frontend): eliminate N+1 double-fetch on recommendations endpoint

### DIFF
--- a/frontend/src/app/(protected)/recommendation/page.tsx
+++ b/frontend/src/app/(protected)/recommendation/page.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import { useEffect, useState } from "react";
-import { apiFetch } from "@/lib/api-client";
+import { apiFetchFull } from "@/lib/api-client";
 import { useAuthStore } from "@/store/useAuthStore";
-import { getBackendUrl } from "@/lib/api-client";
 import Link from "next/link";
 import BookRecommendationGraph from '@/components/features/BookRecommendationGraph';
 
@@ -100,13 +99,13 @@ export default function RecommendationPage() {
       setLoadingRecommendations(true);
 
       try {
-        const rec = await apiFetch<string>(`/recommendations`, {
+        const rec = await apiFetchFull<string>('/recommendations', {
           noCache: true,
         });
 
-        if (rec) {
+        if (rec?.data) {
           setUnavailableMessage(null);
-          const cleanText = rec
+          const cleanText = rec.data
             .replace(/[*_~`>#-]/g, '')
             .replace(/$begin:math:display$(.*?)$end:math:display$$begin:math:text$.*?$end:math:text$/g, '$1')
             .replace(/\n{2,}/g, '\n\n');
@@ -115,21 +114,8 @@ export default function RecommendationPage() {
           // Try to parse structured recommendations
           const parsed = parseRecommendations(cleanText);
           setParsedRecommendations(parsed);
-        } else {
-          // Data is null - check if AI is unavailable by fetching full response
-          const BASE_URL = getBackendUrl();
-          if (BASE_URL) {
-            const fullRes = await fetch(`${BASE_URL}/recommendations`, {
-              credentials: 'include',
-              cache: 'no-store',
-            });
-            if (fullRes.ok) {
-              const json = await fullRes.json();
-              if (json.data === null && json.message) {
-                setUnavailableMessage(json.message);
-              }
-            }
-          }
+        } else if (rec?.message) {
+          setUnavailableMessage(rec.message);
         }
       } catch (error) {
         console.error("❌ Error fetching recommendations:", error);

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -2,9 +2,9 @@ import { handleTokenRefresh } from "./auth";
 import { handleRateLimitResponse } from "./rate-limit-toast";
 
 export interface ApiResponse<T> {
-  data: T;
+  data: T | null;
   status: string;
-  message: string;
+  message: string | null;
 }
 
 export interface ExtendedRequestInit extends RequestInit {
@@ -80,6 +80,51 @@ export class ApiClient {
     }
   }
 
+  async getFull<T>(endpoint: string, options?: ExtendedRequestInit): Promise<ApiResponse<T> | null> {
+    const noCache = options?.noCache;
+
+    try {
+      const res = await fetch(`${this.baseUrl}${endpoint}`, {
+        ...baseFetchConfig,
+        ...options,
+        headers: {
+          ...(options?.headers instanceof Headers
+            ? Object.fromEntries(options.headers.entries())
+            : (options?.headers || {})),
+        },
+        cache: noCache === false ? "force-cache" : "no-store",
+      });
+
+      if (!res.ok) {
+        if (handleRateLimitResponse(res)) {
+          return null;
+        }
+
+        if (res.status === 401) {
+          try {
+            const refreshed = await handleTokenRefresh();
+            if (refreshed) {
+              return await this.getFull<T>(endpoint, options);
+            }
+          } catch (error) {
+            console.error("Token refresh failed:", error);
+            window.location.href = '/login';
+            return null;
+          }
+        }
+
+        console.warn(`⚠️ API error ${res.status} on ${endpoint}`);
+        return null;
+      }
+
+      const json: ApiResponse<T> = await res.json();
+      return json;
+    } catch (err) {
+      console.error(`❌ Failed to fetch ${endpoint}:`, err);
+      return null;
+    }
+  }
+
   async post<T, D = unknown>(
     endpoint: string,
     data: D,
@@ -135,7 +180,7 @@ export class ApiClient {
       }
 
       const json: ApiResponse<T> = await res.json();
-      return json.data;
+      return json.data as T;
     } catch (error) {
       console.error(`Error in POST ${endpoint}:`, error);
       throw error;
@@ -282,3 +327,6 @@ export const apiPut = <T = unknown>(url: string, body: unknown, options?: Reques
 
 export const apiDelete = <T = unknown>(url: string, options?: RequestInit): Promise<T | null> =>
   apiClient.delete<T>(url, options);
+
+export const apiFetchFull = <T>(url: string, options?: ExtendedRequestInit): Promise<ApiResponse<T> | null> =>
+  apiClient.getFull<T>(url, options);

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,6 +1,6 @@
 export interface ApiResponse<T> {
-  data: T;
-  message: string;
+  data: T | null;
+  message: string | null;
   status: string;
 }
 


### PR DESCRIPTION
## Summary

- Fixes #140: the `/recommendations` endpoint was being fetched twice — once via `apiFetch` (which returns only `data`) and a second raw `fetch` when `data` was `null` to retrieve the `message` field
- Added `getFull<T>()` method on `ApiClient` and the `apiFetchFull` top-level wrapper in `frontend/src/lib/api-client.ts` that returns the full `ApiResponse<T>` (both `data` and `message`) from a single request, with token-refresh and rate-limit handling identical to the existing `get<T>()` path
- Updated `frontend/src/app/(protected)/recommendation/page.tsx` to call `apiFetchFull` instead of `apiFetch`, eliminating the second raw `fetch` call entirely
- Fixed `ApiResponse<T>` interface in `frontend/src/lib/api-client.ts` and `frontend/src/types/api.ts`: `data: T | null` and `message: string | null` to accurately reflect the backend schema

## Test plan

- [ ] Navigate to the Recommendations page while authenticated — confirm a recommendation loads without a second network request to `/recommendations`
- [ ] Simulate LLM unavailability (e.g. invalid API key) — confirm the unavailability message is displayed correctly using only one request
- [ ] Confirm TypeScript compiles cleanly: `cd frontend && npx tsc --noEmit`
- [ ] Confirm ESLint passes: `cd frontend && npm run lint`
- [ ] Confirm `next build` succeeds in the frontend
- [ ] Run backend test suite: `pytest` (89 tests should pass)
- [ ] Verify 401 handling: unauthenticated request should trigger token refresh and redirect to `/login` if refresh fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)