### PR TITLE
fix(types): narrow BookStatus from string to union type across frontend (closes #143)

### DIFF
--- a/frontend/src/app/(protected)/library/page.tsx
+++ b/frontend/src/app/(protected)/library/page.tsx
@@ -1,7 +1,7 @@
 // app/library/[user_id]/page.tsx
 
 import UserBookActions from "@/components/user-book-actions";
-import { UserBook, PaginatedResponse, PaginationMetadata } from "@/types";
+import { BookStatus, UserBook, PaginatedResponse, PaginationMetadata } from "@/types";
 import { getBackendUrl, serverSideApiFetch } from "@/lib/api-client";
 import { convertBookToExternalBook } from "@/utils/book";
 import { Metadata } from "next";
@@ -16,11 +16,17 @@ export const metadata: Metadata = {
   description: "Your personal book library",
 };
 
+const VALID_STATUSES: BookStatus[] = ['TO_READ', 'READING', 'READ'];
+
+function parseStatus(raw?: string): BookStatus | undefined {
+  return VALID_STATUSES.find((s) => s === raw);
+}
+
 async function getMyBooksPaginated(
   accessToken: string,
   page: number = 1,
   pageSize: number = 10,
-  status?: string,
+  status?: BookStatus,
 ): Promise<PaginatedResponse<UserBook> | null> {
   const url = new URL(`${getBackendUrl()}/user-books/my-books/paginated`);
   url.searchParams.append("page", page.toString());
@@ -42,7 +48,7 @@ export default async function LibraryPage({
   searchParams: Promise<{ status?: string; page?: string; page_size?: string }>;
 }) {
   const resolvedSearchParams = await searchParams;
-  const statusFilter = resolvedSearchParams.status;
+  const statusFilter = parseStatus(resolvedSearchParams.status);
   const page = parseInt(resolvedSearchParams.page || "1", 10);
   const pageSize = parseInt(resolvedSearchParams.page_size || "10", 10);
   const cookieStore = await cookies();

--- a/frontend/src/components/features/BookRecommendationGraph.tsx
+++ b/frontend/src/components/features/BookRecommendationGraph.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React, { useCallback, useState, useMemo, useEffect } from 'react';
 import { apiFetch } from '@/lib/api-client';
+import { BookStatus } from '@/types';
 import { useAuthStore } from '@/store/useAuthStore';
 import { 
   ReactFlow, 
@@ -26,7 +27,7 @@ interface BookData extends Record<string, unknown> {
   genre?: string;
   book_id?: number;
   external_id?: string;
-  status?: string;
+  status?: BookStatus;
   description?: string;
   is_recommendation?: boolean;
   reasoning?: string;
@@ -81,7 +82,7 @@ const CustomBookNode = ({ data }: { data: BookData }) => {
       {data.status && (
         <div className={`text-xs mt-1 px-2 py-1 rounded text-center ${
           data.status === 'READ' ? 'bg-green-600 text-white' :
-          data.status === 'reading' ? 'bg-blue-600 text-white' :
+          data.status === 'READING' ? 'bg-blue-600 text-white' :
           'bg-gray-600 text-white'
         }`}>
           {data.status.replace('_', ' ').toUpperCase()}

--- a/frontend/src/components/library-pagination.tsx
+++ b/frontend/src/components/library-pagination.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
-import { PaginationMetadata } from "@/types";
+import { BookStatus, PaginationMetadata } from "@/types";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 
 interface LibraryPaginationProps {
   pagination: PaginationMetadata;
-  statusFilter?: string;
+  statusFilter?: BookStatus;
 }
 
 export default function LibraryPagination({ 

--- a/frontend/src/components/user-book-actions.tsx
+++ b/frontend/src/components/user-book-actions.tsx
@@ -2,7 +2,7 @@
 
 "use client";
 
-import { ExternalBook, UserBook } from "@/types";
+import { BookStatus, ExternalBook, UserBook } from "@/types";
 import { apiPost, apiPut } from "@/lib/api-client";
 import { mapGoogleBookToBookCreate } from "@/utils/book";
 import { useRouter } from "next/navigation";
@@ -20,7 +20,7 @@ export default function UserBookActions({
   userBook: initialUserBook,
   book,
 }: Props) {
-  const [status, setStatus] = useState<string | null>(
+  const [status, setStatus] = useState<BookStatus | null>(
     initialUserBook?.status || null,
   );
   const [userBook, setUserBook] = useState<UserBook | null>(initialUserBook);

--- a/frontend/src/services/bookService.ts
+++ b/frontend/src/services/bookService.ts
@@ -1,4 +1,4 @@
-import { Book, ExternalBook, PaginatedResponse, UserBook } from "@/types";
+import { Book, BookStatus, ExternalBook, PaginatedResponse, UserBook } from "@/types";
 import { apiFetch, getBackendUrl } from "@/lib/api-client";
 import { notFound } from "next/navigation";
 
@@ -75,7 +75,7 @@ export const getPopularBooks = async (
 export const getUserBooksPaginated = async (
   page: number = 1,
   pageSize: number = 10,
-  status?: string
+  status?: BookStatus
 ): Promise<PaginatedResponse<UserBook> | null> => {
   const params = new URLSearchParams({
     page: page.toString(),

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -25,6 +25,8 @@ export interface AdminReview {
   created_at: string;
 }
 
+import { BookStatus } from './book';
+
 export interface AdminUserBook {
   id: number;
   user_id: number;
@@ -32,7 +34,7 @@ export interface AdminUserBook {
   book_id: number | null;
   external_book_id: string | null;
   book_title: string | null;
-  status: string;
+  status: BookStatus;
   created_at: string;
 }
 


### PR DESCRIPTION
## Summary
- Replaced loose `string` type with the `'TO_READ' | 'READING' | 'READ'` union (`BookStatus`) across all frontend files that were accepting or passing a book status value: `user-book-actions.tsx`, `bookService.ts`, `BookRecommendationGraph.tsx`, `admin.ts`, `library-pagination.tsx`, and `library/page.tsx`
- Fixed a latent case-mismatch bug in `BookRecommendationGraph.tsx` where `data.status === 'reading'` would never match — corrected to `'READING'`
- Added a `parseStatus()` guard in `library/page.tsx` to validate the URL search param before forwarding it to the API, preventing invalid values from reaching the backend

## Test plan
- [ ] Verify TypeScript compilation passes with no type errors (`tsc --noEmit`)
- [ ] Verify ESLint passes with no new warnings (`npm run lint`)
- [ ] Verify `next build` completes successfully
- [ ] In the UI, switch a book status to each of the three values (TO_READ, READING, READ) and confirm the change persists and the recommendation graph reflects the correct status
- [ ] Navigate to the library page with `?status=READING` (valid) and confirm the filter is applied; try `?status=reading` (invalid) and confirm it is ignored or sanitised gracefully
- [ ] Open the admin panel and confirm status-related fields are still typed and behave correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)