### PR TITLE
fix(frontend): replace <a> with Next.js <Link> in library status filter tabs

### DIFF
--- a/frontend/src/app/(protected)/library/page.tsx
+++ b/frontend/src/app/(protected)/library/page.tsx
@@ -93,7 +93,7 @@ export default async function LibraryPage({
 
       <section className="mb-6 flex justify-center gap-4">
         {filterOptions.map(({ value, label }) => (
-          <a
+          <Link
             key={value}
             href={`?status=${value}`}
             className={`px-4 py-2 rounded cursor-pointer ${
@@ -103,9 +103,9 @@ export default async function LibraryPage({
             }`}
           >
             {label}
-          </a>
+          </Link>
         ))}
-        <a
+        <Link
           href="/library"
           className={`px-4 py-2 rounded cursor-pointer ${
             !statusFilter
@@ -114,7 +114,7 @@ export default async function LibraryPage({
           }`}
         >
           All
-        </a>
+        </Link>
       </section>
 
       <section className="space-y-6">


### PR DESCRIPTION
## Summary
- Replaced plain `<a href>` elements with Next.js `<Link>` in the library page status filter tabs (To Read, Read, Reading, All)
- Previously, clicking any filter tab triggered a full page reload instead of a client-side navigation, discarding in-memory state and causing unnecessary network round-trips
- `Link` was already imported in the file; the fix is a minimal, mechanical substitution (4 lines changed)
- Closes #151

## Test plan
- [x] Navigate to `/library` and click each status filter tab (To Read, Read, Reading, All) — confirm navigation happens without a full page reload (no browser loading spinner, React state preserved)
- [x] Confirm the active tab highlight (`bg-blue-700`) updates correctly on each filter selection
- [x] Confirm the URL query string (`?status=TO_READ`, etc.) updates as expected
- [x] Confirm the All tab (`/library` with no query param) clears the filter correctly
- [x] TypeScript, ESLint, and `next build` all green (already verified in pre-PR build validation)