### PR TITLE
fix(backend): resolve 307 redirect on POST /reviews via trailing slash

### DIFF
--- a/.claude/skills/run/SKILL.md
+++ b/.claude/skills/run/SKILL.md
@@ -1,0 +1,64 @@
+---
+description: "Launch Sonic Library via Docker Compose and verify all services are healthy. Use when asked to run, start, or restart the app, or before manually testing a feature."
+triggers:
+  - run the app
+  - start the app
+  - start docker
+  - bring up services
+  - docker-compose up
+---
+
+# Run Sonic Library
+
+## Services
+
+| Service  | URL                        | Port |
+|----------|----------------------------|------|
+| Frontend | http://localhost:3000      | 3000 |
+| Backend  | http://localhost:8000/docs | 8000 |
+| DB       | PostgreSQL                 | 5432 |
+| Redis    | redis://localhost:6379     | 6379 |
+
+## Steps
+
+### 1. Check if already running
+
+```bash
+docker ps --format "{{.Names}}\t{{.Status}}" | grep sonic-library
+```
+
+If all four containers show `Up`, skip to step 3.
+
+### 2. Start services
+
+Run from project root (`/Users/leonardotonezi/Documents/github/sonic-library`):
+
+```bash
+docker-compose up --build -d
+```
+
+Wait for output confirming `sonic-library-frontend-1  Started`.
+
+### 3. Smoke-check
+
+```bash
+# Backend (expect: Swagger HTML or {"detail":"..."})
+curl -sf http://localhost:8000/docs | head -3
+
+# Frontend (expect: HTML with redirect to /login)
+curl -sf http://localhost:3000 | grep -o 'Sonic Library'
+```
+
+Both must respond. Frontend redirecting to `/login` is correct — the app is protected.
+
+### 4. Stop services (when needed)
+
+```bash
+docker-compose down
+```
+
+## Notes
+
+- Requires `.env` at project root with `SECRET_KEY`, `OPENAI_API_KEY`, `GOOGLE_BOOKS_API_KEY`, mail vars.
+- Test environment uses a separate compose file: `docker-compose -f docker-compose.test.yml up --build` (ports 3001/8001).
+- `--build` flag rebuilds images when source changes. Omit for faster restart when only config changed.

--- a/backend/app/api/v1/endpoints/reviews.py
+++ b/backend/app/api/v1/endpoints/reviews.py
@@ -8,7 +8,7 @@ from app.models.user import User
 from app.schemas.review import ReviewCreate, ReviewResponse, ReviewUpdate
 from app.core.logging_decorator import log_exceptions
 
-router = APIRouter()
+router = APIRouter(redirect_slashes=False)
 
 def get_review_service(
     db: Session = Depends(get_db),
@@ -17,7 +17,7 @@ def get_review_service(
     """Inject ReviewService, requiring authenticated user."""
     return ReviewService(db)
 
-@router.post("/", response_model=ApiResponse[ReviewResponse], status_code=201)
+@router.post("", response_model=ApiResponse[ReviewResponse], status_code=201)
 @log_exceptions("POST /reviews")
 def create(
     review: ReviewCreate,
@@ -29,7 +29,7 @@ def create(
     obj = review_service.create(review_data)
     return ApiResponse(data=ReviewResponse.model_validate(obj))
 
-@router.get("/", response_model=ApiResponse[list[ReviewResponse]])
+@router.get("", response_model=ApiResponse[list[ReviewResponse]])
 @log_exceptions("GET /reviews")
 def index(review_service: ReviewService = Depends(get_review_service)):
     reviews = review_service.get_all()


### PR DESCRIPTION
## Summary
- Next.js strips trailing slashes before rewrites (`trailingSlash: false` default), so `POST /api/backend/reviews/` was being forwarded to FastAPI as `POST /reviews` (no trailing slash), which triggered a 307 redirect back to `/reviews/` — dropping the request body and causing the \"Failed to add review\" error in the frontend
- Set `redirect_slashes=False` on the `APIRouter` in `backend/app/api/v1/endpoints/reviews.py` so FastAPI no longer issues redirects for missing trailing slashes
- Changed `@router.post("/")` and `@router.get("/")` to `@router.post("")` and `@router.get("")` to match the slash-free path the proxy sends
- Adds `.claude/skills/run/SKILL.md` — a Docker Compose launch skill for the project

## Test plan
- [x] Start the app via Docker Compose (`docker-compose up --build`)
- [x] Log in and navigate to a book detail page
- [x] Submit a review — confirm it saves successfully with no 307 redirect in the network tab
- [x] Fetch the reviews list for the book — confirm it returns results without redirect
- [x] Confirm no regression on other review-related endpoints (GET /reviews/{id}, etc.)