### PR TITLE
feat: v1 release — auth, Next.js 15, Suspense streaming, E2E suite, and tooling

### DIFF
--- a/.claude/agents/pr-creator.md
+++ b/.claude/agents/pr-creator.md
@@ -33,7 +33,6 @@ You are the PR creator for Sonic Library. You open pull requests using `gh pr cr
 ## Test plan
 - [ ] checklist of what to verify before merging
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ```
 
 ## Rules

--- a/.claude/skills/run/SKILL.md
+++ b/.claude/skills/run/SKILL.md
@@ -1,0 +1,64 @@
+---
+description: "Launch Sonic Library via Docker Compose and verify all services are healthy. Use when asked to run, start, or restart the app, or before manually testing a feature."
+triggers:
+  - run the app
+  - start the app
+  - start docker
+  - bring up services
+  - docker-compose up
+---
+
+# Run Sonic Library
+
+## Services
+
+| Service  | URL                        | Port |
+|----------|----------------------------|------|
+| Frontend | http://localhost:3000      | 3000 |
+| Backend  | http://localhost:8000/docs | 8000 |
+| DB       | PostgreSQL                 | 5432 |
+| Redis    | redis://localhost:6379     | 6379 |
+
+## Steps
+
+### 1. Check if already running
+
+```bash
+docker ps --format "{{.Names}}\t{{.Status}}" | grep sonic-library
+```
+
+If all four containers show `Up`, skip to step 3.
+
+### 2. Start services
+
+Run from project root (`/Users/leonardotonezi/Documents/github/sonic-library`):
+
+```bash
+docker-compose up --build -d
+```
+
+Wait for output confirming `sonic-library-frontend-1  Started`.
+
+### 3. Smoke-check
+
+```bash
+# Backend (expect: Swagger HTML or {"detail":"..."})
+curl -sf http://localhost:8000/docs | head -3
+
+# Frontend (expect: HTML with redirect to /login)
+curl -sf http://localhost:3000 | grep -o 'Sonic Library'
+```
+
+Both must respond. Frontend redirecting to `/login` is correct — the app is protected.
+
+### 4. Stop services (when needed)
+
+```bash
+docker-compose down
+```
+
+## Notes
+
+- Requires `.env` at project root with `SECRET_KEY`, `OPENAI_API_KEY`, `GOOGLE_BOOKS_API_KEY`, mail vars.
+- Test environment uses a separate compose file: `docker-compose -f docker-compose.test.yml up --build` (ports 3001/8001).
+- `--build` flag rebuilds images when source changes. Omit for faster restart when only config changed.

--- a/backend/app/api/v1/endpoints/reviews.py
+++ b/backend/app/api/v1/endpoints/reviews.py
@@ -8,7 +8,7 @@ from app.models.user import User
 from app.schemas.review import ReviewCreate, ReviewResponse, ReviewUpdate
 from app.core.logging_decorator import log_exceptions
 
-router = APIRouter()
+router = APIRouter(redirect_slashes=False)
 
 def get_review_service(
     db: Session = Depends(get_db),
@@ -17,7 +17,7 @@ def get_review_service(
     """Inject ReviewService, requiring authenticated user."""
     return ReviewService(db)
 
-@router.post("/", response_model=ApiResponse[ReviewResponse], status_code=201)
+@router.post("", response_model=ApiResponse[ReviewResponse], status_code=201)
 @log_exceptions("POST /reviews")
 def create(
     review: ReviewCreate,
@@ -29,7 +29,7 @@ def create(
     obj = review_service.create(review_data)
     return ApiResponse(data=ReviewResponse.model_validate(obj))
 
-@router.get("/", response_model=ApiResponse[list[ReviewResponse]])
+@router.get("", response_model=ApiResponse[list[ReviewResponse]])
 @log_exceptions("GET /reviews")
 def index(review_service: ReviewService = Depends(get_review_service)):
     reviews = review_service.get_all()

--- a/frontend/src/app/(protected)/books/[id]/page.tsx
+++ b/frontend/src/app/(protected)/books/[id]/page.tsx
@@ -41,49 +41,40 @@ export default async function BookPage({
     notFound();
   }
 
+  let book: Book;
   try {
-    const book = await getBookData(id, accessToken);
-
-    if (!book) {
-      notFound();
-    }
-
-    return (
-      <div className="p-6 bg-blue-950 text-blue-50 min-h-screen flex flex-col items-center">
-        <div className="relative bg-blue-900 border border-blue-600 p-6 rounded-lg shadow-md max-w-2xl w-full mb-6">
-          <div className="flex justify-between items-start">
-            <h1 className="text-3xl font-bold text-blue-500 mb-2">
-              {book.title}
-            </h1>
-          </div>
-          <p className="text-sm italic text-blue-100 mb-4">By {book.author}</p>
-          {book.description && (
-            <p className="text-blue-200 leading-relaxed">{book.description}</p>
-          )}
-        </div>
-
-        <AddReviewForm bookId={book?.id} />
-        <Suspense fallback={<ReviewsSkeleton />}>
-          <ReviewsList bookId={id} token={accessToken} />
-        </Suspense>
-      </div>
-    );
+    book = await getBookData(id, accessToken);
   } catch (error) {
     if (error instanceof Error && error.message.includes('401')) {
       redirect('/login');
     }
-    return (
-      <div className="p-6 bg-blue-950 text-red-400 min-h-screen flex items-center justify-center">
-        <div className="bg-red-900/50 p-4 rounded-lg max-md text-center">
-          <h2 className="text-xl font-semibold mb-2">Error Loading Book</h2>
-          <p>
-            We encountered an error while loading this book. Please try again
-            later.
-          </p>
-        </div>
-      </div>
-    );
+    throw error;
   }
+
+  if (!book) {
+    notFound();
+  }
+
+  return (
+    <div className="p-6 bg-blue-950 text-blue-50 min-h-screen flex flex-col items-center">
+      <div className="relative bg-blue-900 border border-blue-600 p-6 rounded-lg shadow-md max-w-2xl w-full mb-6">
+        <div className="flex justify-between items-start">
+          <h1 className="text-3xl font-bold text-blue-500 mb-2">
+            {book.title}
+          </h1>
+        </div>
+        <p className="text-sm italic text-blue-100 mb-4">By {book.author}</p>
+        {book.description && (
+          <p className="text-blue-200 leading-relaxed">{book.description}</p>
+        )}
+      </div>
+
+      <AddReviewForm bookId={book?.id} />
+      <Suspense fallback={<ReviewsSkeleton />}>
+        <ReviewsList bookId={id} token={accessToken} />
+      </Suspense>
+    </div>
+  );
 }
 
 export async function generateMetadata({

--- a/frontend/src/app/(protected)/books/external/[externalId]/page.tsx
+++ b/frontend/src/app/(protected)/books/external/[externalId]/page.tsx
@@ -113,102 +113,91 @@ export default async function ExternalBookPage({ params }: Props) {
   const cookieStore = await cookies();
   const accessToken = cookieStore.get("access_token")?.value ?? '';
 
+  let book: ExternalBook;
+  let userBook: UserBook;
+  let reviews: Review[];
   try {
-    const { book, userBook, reviews } = await getExternalBookData(
-      externalId,
-      accessToken,
-    );
-
-    if (!book) notFound();
-
-    return (
-      <div className="p-6 bg-blue-950 text-blue-50 min-h-screen flex flex-col items-center">
-        <div className="relative bg-blue-900 border border-blue-600 p-6 rounded-lg shadow-md max-w-2xl w-full mb-6">
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <div className="md:col-span-1">
-              {book.thumbnail && (
-                <Image
-                  src={book.thumbnail.replace(/^http:\/\//, 'https://')}
-                  alt={book.title}
-                  width={80}
-                  height={80}
-                  className="w-full rounded-md shadow-md"
-                />
-              )}
-            </div>
-
-            <div className="md:col-span-2">
-              <div className="flex justify-between items-start">
-                <h1 className="text-3xl font-bold text-blue-500 mb-2">
-                  {book.title}
-                </h1>
-              </div>
-
-              <p className="text-sm italic text-blue-100 mb-4">
-                By {book.authors?.join(", ") || "Unknown Author"}
-              </p>
-
-              {book.description && (
-                <p className="text-blue-200 leading-relaxed mb-4">
-                  {book.description}
-                </p>
-              )}
-
-              {/* Additional Info */}
-              <div className="text-blue-200 space-y-2">
-                <p>
-                  <span className="font-semibold">Published:</span>{" "}
-                  {book.publishedDate}
-                </p>
-                <p>
-                  <span className="font-semibold">Pages:</span> {book.pageCount}
-                </p>
-                <p>
-                  <span className="font-semibold">Language:</span>{" "}
-                  {book.language}
-                </p>
-                {book.categories && book.categories.length > 0 && (
-                  <p>
-                    <span className="font-semibold">Categories:</span>{" "}
-                    {book.categories.join(", ")}
-                  </p>
-                )}
-              </div>
-
-              <UserBookActions
-                externalId={externalId}
-                userBook={userBook}
-                book={book}
-              />
-              {userBook && (
-                <ExternalBookPageClient
-                  userBook={userBook}
-                  externalId={externalId}
-                />
-              )}
-            </div>
-          </div>
-
-          <div className="mt-5">
-            <ExternalReviewsList reviews={reviews} />
-          </div>
-        </div>
-      </div>
-    );
+    ({ book, userBook, reviews } = await getExternalBookData(externalId, accessToken));
   } catch (error) {
     if (error instanceof Error && error.message.includes('401')) {
       redirect('/login');
     }
-    return (
-      <div className="p-6 bg-blue-950 text-red-400 min-h-screen flex items-center justify-center">
-        <div className="bg-red-900/50 p-4 rounded-lg max-w-md text-center">
-          <h2 className="text-xl font-semibold mb-2">Error Loading Book</h2>
-          <p>
-            We encountered an error while loading this book. Please try again
-            later.
-          </p>
+    throw error;
+  }
+
+  if (!book) notFound();
+
+  return (
+    <div className="p-6 bg-blue-950 text-blue-50 min-h-screen flex flex-col items-center">
+      <div className="relative bg-blue-900 border border-blue-600 p-6 rounded-lg shadow-md max-w-2xl w-full mb-6">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          <div className="md:col-span-1">
+            {book.thumbnail && (
+              <Image
+                src={book.thumbnail.replace(/^http:\/\//, 'https://')}
+                alt={book.title}
+                width={80}
+                height={80}
+                className="w-full rounded-md shadow-md"
+              />
+            )}
+          </div>
+
+          <div className="md:col-span-2">
+            <div className="flex justify-between items-start">
+              <h1 className="text-3xl font-bold text-blue-500 mb-2">
+                {book.title}
+              </h1>
+            </div>
+
+            <p className="text-sm italic text-blue-100 mb-4">
+              By {book.authors?.join(", ") || "Unknown Author"}
+            </p>
+
+            {book.description && (
+              <p className="text-blue-200 leading-relaxed mb-4">
+                {book.description}
+              </p>
+            )}
+
+            <div className="text-blue-200 space-y-2">
+              <p>
+                <span className="font-semibold">Published:</span>{" "}
+                {book.publishedDate}
+              </p>
+              <p>
+                <span className="font-semibold">Pages:</span> {book.pageCount}
+              </p>
+              <p>
+                <span className="font-semibold">Language:</span>{" "}
+                {book.language}
+              </p>
+              {book.categories && book.categories.length > 0 && (
+                <p>
+                  <span className="font-semibold">Categories:</span>{" "}
+                  {book.categories.join(", ")}
+                </p>
+              )}
+            </div>
+
+            <UserBookActions
+              externalId={externalId}
+              userBook={userBook}
+              book={book}
+            />
+            {userBook && (
+              <ExternalBookPageClient
+                userBook={userBook}
+                externalId={externalId}
+              />
+            )}
+          </div>
+        </div>
+
+        <div className="mt-5">
+          <ExternalReviewsList reviews={reviews} />
         </div>
       </div>
-    );
-  }
+    </div>
+  );
 }

--- a/frontend/src/app/(protected)/error.tsx
+++ b/frontend/src/app/(protected)/error.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+export default function ProtectedError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="min-h-screen bg-blue-950 flex items-center justify-center px-4">
+      <div className="bg-blue-900 border border-blue-800 rounded-lg p-8 max-w-md w-full text-center shadow-lg">
+        <h2 className="text-2xl font-bold text-blue-200 mb-3">Something went wrong</h2>
+        <p className="text-blue-400 mb-6">
+          {error.message || 'An unexpected error occurred. Please try again.'}
+        </p>
+        <button
+          onClick={reset}
+          className="bg-blue-600 hover:bg-blue-500 text-white font-semibold px-6 py-2 rounded-lg transition-colors"
+        >
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(protected)/library/page.tsx
+++ b/frontend/src/app/(protected)/library/page.tsx
@@ -93,7 +93,7 @@ export default async function LibraryPage({
 
       <section className="mb-6 flex justify-center gap-4">
         {filterOptions.map(({ value, label }) => (
-          <a
+          <Link
             key={value}
             href={`?status=${value}`}
             className={`px-4 py-2 rounded cursor-pointer ${
@@ -103,9 +103,9 @@ export default async function LibraryPage({
             }`}
           >
             {label}
-          </a>
+          </Link>
         ))}
-        <a
+        <Link
           href="/library"
           className={`px-4 py-2 rounded cursor-pointer ${
             !statusFilter
@@ -114,7 +114,7 @@ export default async function LibraryPage({
           }`}
         >
           All
-        </a>
+        </Link>
       </section>
 
       <section className="space-y-6">

--- a/frontend/src/app/(protected)/loading.tsx
+++ b/frontend/src/app/(protected)/loading.tsx
@@ -1,0 +1,7 @@
+export default function ProtectedLoading() {
+  return (
+    <div className="min-h-screen bg-blue-950 flex items-center justify-center">
+      <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500"></div>
+    </div>
+  );
+}

--- a/frontend/src/app/(public)/error.tsx
+++ b/frontend/src/app/(public)/error.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+export default function PublicError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="min-h-screen bg-blue-950 flex items-center justify-center px-4">
+      <div className="bg-blue-900 border border-blue-800 rounded-lg p-8 max-w-md w-full text-center shadow-lg">
+        <h2 className="text-2xl font-bold text-blue-200 mb-3">Something went wrong</h2>
+        <p className="text-blue-400 mb-6">
+          {error.message || 'An unexpected error occurred. Please try again.'}
+        </p>
+        <button
+          onClick={reset}
+          className="bg-blue-600 hover:bg-blue-500 text-white font-semibold px-6 py-2 rounded-lg transition-colors"
+        >
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(public)/loading.tsx
+++ b/frontend/src/app/(public)/loading.tsx
@@ -1,0 +1,7 @@
+export default function PublicLoading() {
+  return (
+    <div className="min-h-screen bg-blue-950 flex items-center justify-center">
+      <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500"></div>
+    </div>
+  );
+}

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen bg-blue-950 flex items-center justify-center px-4">
+      <div className="bg-blue-900 border border-blue-800 rounded-lg p-8 max-w-md w-full text-center shadow-lg">
+        <h1 className="text-6xl font-bold text-blue-500 mb-4">404</h1>
+        <h2 className="text-2xl font-semibold text-blue-200 mb-3">Page not found</h2>
+        <p className="text-blue-400 mb-8">
+          The page you are looking for does not exist or has been moved.
+        </p>
+        <Link
+          href="/books"
+          className="bg-blue-600 hover:bg-blue-500 text-white font-semibold px-6 py-2 rounded-lg transition-colors inline-block"
+        >
+          Go to Library
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

This is the full development cycle release merging all features, fixes, and infrastructure improvements accumulated on `development` into `master`.

### Auth & Security
- Server-side auth gating via Next.js middleware (#132)
- Centralized auth hydration in root layout — eliminates duplicate `/users/me` calls
- Server-side admin auth via `is_admin` on `/users/me` (closes #134)
- Moved NavBar to protected layout and added auth guards on library page (closes #171, #172)
- Replaced broken token-refresh queue and unsafe `force-cache` default
- HTTP-only cookie flow enforced throughout; no JWT in localStorage

### Frontend — Next.js 15 & Architecture
- Upgraded Next.js from 9.3.3 to 15.5.15 (security fixes)
- Converted root page to server component redirect
- Routed all browser API calls through Next.js proxy to bypass Vercel WAF cross-origin block
- Used `BACKEND_INTERNAL_URL` for Next.js proxy rewrite in Docker
- Fixed `useSearchParams` wrapped in Suspense on admin, settings, login, and library pages
- Streamed reviews section via Suspense on book detail page
- Added error/loading segments and refactored book error handling (closes #142)
- Added `not-found.tsx` and protected/public error and loading boundaries
- Resolved 307 redirect on POST `/reviews` via Next.js proxy

### Frontend — Types & Data
- Narrowed `BookStatus` from `string` to union type across frontend (closes #133)
- Extended `BookStatus` narrowing to admin, pagination, and library pages
- Consolidated type hierarchies and fixed `BookStatus` enum
- Replaced unsafe `BookRecommendation` casts with explicit field constructors
- Replaced unsafe tab cast with type guard; added invalid tab error state
- Eliminated N+1 double-fetch on recommendations endpoint

### Frontend — Fixes
- Used `getBackendUrl()` in external book and library server components
- Fixed book page 401, image loading, add-book 307, and mail crash
- Removed `console.error` from external book page
- Removed all `console.log` calls; added `no-console` ESLint rule
- Renamed `merriwether` to `merriweather` in `layout.tsx`
- Added validation to Google Books API call

### Backend
- Removed `is_testing` flag from books endpoints
- Skipped file log handler when filesystem is read-only (Vercel)
- Guarded upload dir `mkdir` against read-only filesystem (Vercel)
- Loaded `.env.test` only when `TESTING=true`, not by file existence

### E2E Testing (Playwright)
- Added Playwright test suite with shared auth state and parallel workers for faster CI
- Switched `testMatch` to glob patterns; added `testIgnore` for fixtures
- Hydrated auth store on protected pages; fixed duplicate email test
- Added `BACKEND_INTERNAL_URL` to frontend-test service in `docker-compose`
- Bypassed Google Books in TESTING mode for stable runs
- Waited for popular books API response before asserting DOM
- Replaced fragile `waitForResponse(201)` with toast assertion
- Skipped flaky add-book spec pending root cause analysis
- Added Suspense E2E test

### Tooling & DX
- Added project-specific Claude Code sub-agents: `project-planner`, `frontend-worker`, `backend-worker`, `feature-evaluator`, `build-validator`, `pr-creator`
- Rewrote `build-validator` to faithfully mirror `ci.yml`
- Added weekly `dev→master` sync PR GitHub Actions workflow
- Added `create_issue.py` script for bulk GitHub issue creation
- Added agent principles to `CLAUDE.md`
- Added live demo URL to README
- Removed Claude Code footer from `pr-creator` agent template

## Test plan
- [x] Auth flow: sign in, verify cookie set, no duplicate `/users/me` calls in network tab
- [x] Admin route: non-admin user cannot access `/admin`; admin user can
- [x] NavBar visible only on protected routes; library page redirects unauthenticated users
- [x] Book detail page streams reviews section without blocking initial render
- [x] Error and loading boundaries render correctly on network failure / slow load
- [x] POST `/reviews` does not 307-redirect; review is saved correctly
- [x] `BookStatus` type errors absent — run `npm run build` in `/frontend`
- [x] Recommendations page makes a single fetch (no N+1)
- [x] E2E suite passes: `docker-compose -f docker-compose.test.yml up --build`
- [x] Vercel deployment: no WAF cross-origin errors in browser console
- [x] Upload endpoint works on read-only filesystem (Vercel) without crashing