### PR TITLE
feat: replace books page spinner with skeleton cards

### DIFF
--- a/frontend/src/app/(protected)/books/books-skeleton.tsx
+++ b/frontend/src/app/(protected)/books/books-skeleton.tsx
@@ -1,0 +1,32 @@
+export default function BooksSkeleton() {
+  return (
+    <>
+      <div className="h-7 w-48 bg-blue-700 rounded animate-pulse mb-6" />
+      <ul className="space-y-4">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <li
+            key={i}
+            className="bg-blue-900 border border-blue-600 p-4 rounded-lg shadow-md"
+          >
+            <div className="flex">
+              <div className="w-24 h-32 bg-blue-700 rounded mr-4 shrink-0 animate-pulse" />
+              <div className="flex-1">
+                <div className="h-5 w-3/4 bg-blue-700 rounded animate-pulse" />
+                <div className="h-3 w-1/2 bg-blue-700 rounded animate-pulse mt-2" />
+                <div className="mt-2">
+                  <div className="h-3 w-full bg-blue-700 rounded animate-pulse mb-2" />
+                  <div className="h-3 w-full bg-blue-700 rounded animate-pulse mb-2" />
+                  <div className="h-3 w-4/5 bg-blue-700 rounded animate-pulse" />
+                </div>
+                <div className="mt-2 flex gap-2">
+                  <div className="h-3 w-16 bg-blue-700 rounded animate-pulse" />
+                  <div className="h-3 w-24 bg-blue-700 rounded animate-pulse" />
+                </div>
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}

--- a/frontend/src/app/(protected)/books/page.tsx
+++ b/frontend/src/app/(protected)/books/page.tsx
@@ -4,7 +4,8 @@ import Link from "next/link";
 import Image from "next/image";
 import { useEffect } from "react";
 import { useSearchBookStore } from "@/store/useSearchBookStore";
-import { AlertTriangle, Book, Loader2 } from "lucide-react";
+import { AlertTriangle, Book } from "lucide-react";
+import BooksSkeleton from "./books-skeleton";
 import { Pagination } from "@/components/pagination";
 
 export default function BooksPage() {
@@ -36,14 +37,11 @@ export default function BooksPage() {
     fetchPopularBooksPaginated(page);
   };
 
-  // Show loading spinner when search is in progress
+  // Show skeleton cards when loading is in progress
   if (isLoading) {
     return (
-      <div className="p-6 bg-[#0a1128] text-white min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <Loader2 className="w-12 h-12 text-blue-400 animate-spin mx-auto mb-4" />
-          <p className="text-blue-200 text-lg">Searching for books...</p>
-        </div>
+      <div className="p-6 bg-[#0a1128] text-white min-h-screen">
+        <BooksSkeleton />
       </div>
     );
   }


### PR DESCRIPTION
## Summary

- Adds `BooksSkeleton` component (`books-skeleton.tsx`) with 5 animated placeholder cards matching the real book card layout: thumbnail block, title bar, authors line, three description lines, and meta chips
- Replaces the full-screen `Loader2` spinner in `BooksPage` with `<BooksSkeleton />` — active for both the initial popular-books fetch and any search query
- Removes the now-unused `Loader2` import from `page.tsx`
- Follows the same structural pattern as the existing `reviews-skeleton.tsx`

## Test plan

- [x] Navigate to `/books` while logged in — skeleton cards should appear briefly before popular books load
- [x] Run a search from the navbar — skeleton cards should show while results are fetching, then be replaced by the result list
- [x] Confirm no full-screen spinner appears anywhere on the /books page
- [x] Verify skeleton card dimensions (thumbnail, title, authors, description, meta) visually match the real `BookCard` layout
- [x] `npm run lint` passes with no new errors
- [x] No `console.log` or leftover `Loader2` import in `page.tsx`