### PR TITLE
fix(frontend): redirect to /login on 401 instead of silent empty state

### DIFF
--- a/frontend/src/app/(protected)/books/[id]/page.tsx
+++ b/frontend/src/app/(protected)/books/[id]/page.tsx
@@ -6,7 +6,7 @@ import ReviewsList from "./review-list";
 import ReviewsSkeleton from "./reviews-skeleton";
 import { Book } from "@/types";
 import { ApiResponse } from "@/types";
-import { serverSideApiFetch, getBackendUrl } from "@/lib/api-client";
+import { serverSideApiFetch, getBackendUrl, ApiError } from "@/lib/api-client";
 
 export const dynamic = "force-dynamic";
 
@@ -37,6 +37,10 @@ export default async function BookPage({
   const cookieStore = await cookies();
   const accessToken = cookieStore.get("access_token")?.value ?? '';
 
+  if (!accessToken) {
+    redirect('/login');
+  }
+
   if (!id || isNaN(Number(id))) {
     notFound();
   }
@@ -45,7 +49,7 @@ export default async function BookPage({
   try {
     book = await getBookData(id, accessToken);
   } catch (error) {
-    if (error instanceof Error && error.message.includes('401')) {
+    if (error instanceof ApiError && error.status === 401) {
       redirect('/login');
     }
     throw error;

--- a/frontend/src/app/(protected)/books/[id]/review-list.tsx
+++ b/frontend/src/app/(protected)/books/[id]/review-list.tsx
@@ -3,7 +3,8 @@ import { ApiResponse } from "@/types";
 import ReviewActions from "./review-actions";
 import { Star, User } from "lucide-react";
 import Image from "next/image";
-import { serverSideApiFetch, getBackendUrl } from "@/lib/api-client";
+import { redirect } from "next/navigation";
+import { serverSideApiFetch, getBackendUrl, ApiError } from "@/lib/api-client";
 
 const renderStars = (rate: number) => {
   return Array.from({ length: 5 }, (_, i) => (
@@ -28,11 +29,20 @@ type ReviewsListProps = {
 };
 
 export default async function ReviewsList({ bookId, token }: ReviewsListProps) {
-  const reviewsData = (await serverSideApiFetch(
-    `${getBackendUrl()}/reviews/book/${bookId}`,
-    token,
-    { cache: 'no-store' },
-  )) as ApiResponse<Review[]> | null;
+  let reviewsData: ApiResponse<Review[]> | null = null;
+
+  try {
+    reviewsData = (await serverSideApiFetch(
+      `${getBackendUrl()}/reviews/book/${bookId}`,
+      token,
+      { cache: 'no-store' },
+    )) as ApiResponse<Review[]> | null;
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 401) {
+      redirect('/login');
+    }
+    throw error;
+  }
 
   const reviews: Review[] = reviewsData?.data ?? [];
 

--- a/frontend/src/app/(protected)/books/external/[externalId]/page.tsx
+++ b/frontend/src/app/(protected)/books/external/[externalId]/page.tsx
@@ -3,7 +3,7 @@
 import { cookies } from "next/headers";
 import { notFound, redirect } from "next/navigation";
 import { ApiResponse } from "@/types";
-import { getBackendUrl, serverSideApiFetch } from "@/lib/api-client";
+import { getBackendUrl, serverSideApiFetch, ApiError } from "@/lib/api-client";
 import Image from "next/image";
 import { Star, User } from "lucide-react";
 import { ExternalBook, UserBook, Review } from "@/types";
@@ -80,28 +80,24 @@ async function getExternalBookData(
   externalId: string,
   accessToken: string,
 ): Promise<{ book: ExternalBook; userBook: UserBook; reviews: Review[] }> {
-  try {
-    const response = (await serverSideApiFetch(
-      `${getBackendUrl()}/books/external/${externalId}`,
-      accessToken,
-      {
-        cache: 'no-store',
-      },
-    )) as ApiResponse<{
-      book: ExternalBook;
-      userBook: UserBook;
-      reviews: Review[];
-    }>;
-    const data = response.data;
+  const response = (await serverSideApiFetch(
+    `${getBackendUrl()}/books/external/${externalId}`,
+    accessToken,
+    {
+      cache: 'no-store',
+    },
+  )) as ApiResponse<{
+    book: ExternalBook;
+    userBook: UserBook;
+    reviews: Review[];
+  }>;
+  const data = response.data;
 
-    if (!data || !data.book || !data.book.external_id) {
-      throw new Error("Invalid book data received");
-    }
-
-    return data;
-  } catch (error) {
-    throw error;
+  if (!data || !data.book || !data.book.external_id) {
+    throw new Error("Invalid book data received");
   }
+
+  return data;
 }
 
 type Props = {
@@ -113,13 +109,17 @@ export default async function ExternalBookPage({ params }: Props) {
   const cookieStore = await cookies();
   const accessToken = cookieStore.get("access_token")?.value ?? '';
 
+  if (!accessToken) {
+    redirect('/login');
+  }
+
   let book: ExternalBook;
   let userBook: UserBook;
   let reviews: Review[];
   try {
     ({ book, userBook, reviews } = await getExternalBookData(externalId, accessToken));
   } catch (error) {
-    if (error instanceof Error && error.message.includes('401')) {
+    if (error instanceof ApiError && error.status === 401) {
       redirect('/login');
     }
     throw error;

--- a/frontend/src/app/(protected)/library/page.tsx
+++ b/frontend/src/app/(protected)/library/page.tsx
@@ -2,7 +2,7 @@
 
 import UserBookActions from "@/components/user-book-actions";
 import { BookStatus, UserBook, PaginatedResponse, PaginationMetadata } from "@/types";
-import { getBackendUrl, serverSideApiFetch } from "@/lib/api-client";
+import { getBackendUrl, serverSideApiFetch, ApiError } from "@/lib/api-client";
 import { convertBookToExternalBook } from "@/utils/book";
 import { Metadata } from "next";
 import { redirect } from 'next/navigation';
@@ -69,9 +69,10 @@ export default async function LibraryPage({
       paginationData = data.pagination;
     }
   } catch (error) {
-    if (error instanceof Error && error.message.includes('401')) {
+    if (error instanceof ApiError && error.status === 401) {
       redirect('/login');
     }
+    throw error;
   }
 
   function truncate(text: string, maxLength: number) {

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -1,6 +1,16 @@
 import { handleTokenRefresh } from "./auth";
 import { handleRateLimitResponse } from "./rate-limit-toast";
 
+export class ApiError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+  }
+}
+
 export interface ApiResponse<T> {
   data: T | null;
   status: string;
@@ -306,7 +316,7 @@ export async function serverSideApiFetch(
   }
 
   if (!response.ok) {
-    throw new Error(`API error: ${response.status}`);
+    throw new ApiError(response.status, `HTTP error! status: ${response.status}`);
   }
 
   return response.json();

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,9 +1,32 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
+function isJwtExpired(token: string): boolean {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return false;
+
+    // Base64url → base64 → decode
+    const payload = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const padded = payload + '='.repeat((4 - payload.length % 4) % 4);
+    const decoded = JSON.parse(atob(padded)) as { exp?: number };
+
+    if (typeof decoded.exp !== 'number') return false;
+    return decoded.exp < Date.now() / 1000;
+  } catch {
+    // If decoding fails, let the backend decide
+    return false;
+  }
+}
+
 export function middleware(request: NextRequest) {
-  const token = request.cookies.get('access_token');
-  if (!token) return NextResponse.redirect(new URL('/login', request.url));
+  const tokenCookie = request.cookies.get('access_token');
+  if (!tokenCookie) return NextResponse.redirect(new URL('/login', request.url));
+
+  if (isJwtExpired(tokenCookie.value)) {
+    return NextResponse.redirect(new URL('/login', request.url));
+  }
+
   return NextResponse.next();
 }
 


### PR DESCRIPTION
## Summary

- Adds `ApiError extends Error` class with a `.status: number` field to `api-client.ts`. `serverSideApiFetch` now throws `ApiError` instead of a generic `Error`, making it possible to reliably distinguish HTTP status codes in catch blocks.
- Adds `isJwtExpired()` helper to `middleware.ts` that decodes the JWT payload (base64url, no external deps) and checks the `exp` claim. Middleware now redirects expired tokens to `/login`, not just missing cookies.
- Updates `library/page.tsx`, `books/[id]/page.tsx`, `books/[id]/review-list.tsx`, and `books/external/[externalId]/page.tsx` to catch `ApiError` with `status === 401` and redirect to `/login`. Non-401 errors are re-thrown instead of being silently swallowed.
- Removes dead no-op inner try/catch in `getExternalBookData` (external book page).
- Adds empty-token guard + immediate redirect at the top of the two book detail pages.

Closes #172

## Test plan

- [x] Log in, let the session cookie expire (or manually delete/corrupt it), then navigate to `/library` — confirm redirect to `/login` rather than blank page.
- [x] Repeat for `/books/<id>` and `/books/external/<externalId>` with an expired/missing token.
- [x] Confirm that a fresh authenticated session still loads library and book pages normally.
- [x] Confirm that a 500 from the backend is still surfaced as an error (not swallowed and not redirected to login).
- [x] TypeScript: `npm run tsc --noEmit` returns 0 errors.
- [x] ESLint: `npm run lint` returns 0 errors.
- [x] `next build` completes cleanly across all 12 pages.