### PR TITLE
release: development → master (2026-06-13)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,121 @@
+---
+description: "Analyze differences between development and master, then open a release PR. Use when asked to 'create a release', 'open release PR', 'release to master', 'ship development to master', or '/release'."
+triggers:
+  - create a release
+  - open release PR
+  - release to master
+  - ship to master
+  - ship development
+  - release
+---
+
+# Release Skill
+
+Compares `development` → `master`, summarizes all changes, opens a PR.
+
+## Steps
+
+### 1. Verify branch state
+
+```bash
+git fetch origin
+git log origin/master..origin/development --oneline
+```
+
+If output is empty → nothing to release. Stop and tell user.
+
+### 2. Gather diff data (run in parallel)
+
+```bash
+# All commits not yet in master
+git log origin/master..origin/development --oneline --no-merges
+
+# Files changed
+git diff --stat origin/master...origin/development
+
+# Full diff (for PR body summary)
+git diff --name-only origin/master...origin/development
+```
+
+### 3. Categorize changes
+
+Group changed files by area:
+- `backend/` → Backend
+- `frontend/` → Frontend
+- `.github/` → CI/CD
+- `docker*` / `*.yml` at root → Infrastructure
+- `*.md` → Docs
+
+### 4. Draft PR title and body
+
+**Title format:** `release: development → master (YYYY-MM-DD)`
+
+**Body format:**
+
+```markdown
+## What's included
+
+### Backend
+- bullet per meaningful change
+
+### Frontend  
+- bullet per meaningful change
+
+### CI/CD / Infrastructure
+- bullet per meaningful change
+
+## PRs merged
+- #NNN Title
+- #NNN Title
+
+## Checklist
+- [ ] All CI checks pass on `development`
+- [ ] No `.env` or secrets committed
+- [ ] Migrations included if schema changed
+```
+
+Derive bullets from commit messages and changed file list. List merged PRs by scanning merge commits (`git log --merges --oneline origin/master..origin/development`).
+
+### 5. Ensure on correct branch
+
+```bash
+git checkout development
+git pull origin development
+```
+
+### 6. Open PR
+
+```bash
+gh pr create \
+  --base master \
+  --head development \
+  --title "release: development → master ($(date +%Y-%m-%d))" \
+  --body "$(cat <<'EOF'
+<body from step 4>
+EOF
+)"
+```
+
+Return the PR URL to the user.
+
+### 7. Assign and label the PR
+
+Use the REST API directly (avoid `gh pr edit` which has GraphQL issues with deprecated Projects classic):
+
+```bash
+# Get the PR number from step 6 output
+gh api repos/{owner}/{repo}/issues/{PR_NUMBER}/assignees \
+  -X POST -f 'assignees[]={github_username}'
+
+gh api repos/{owner}/{repo}/issues/{PR_NUMBER}/labels \
+  -X POST -f 'labels[]=release'
+```
+
+- `{github_username}` = the authenticated user (`gh api user --jq .login`)
+- Create the `release` label first if it doesn't exist: `gh label create "release" --color "0075ca" --description "Release PR"`
+
+## Edge cases
+
+- **Already open PR** → `gh pr list --base master --head development` — if one exists, link to it instead of creating a new one.
+- **No commits ahead** → stop early, nothing to release.
+- **Conflicts** → warn user: "development has conflicts with master — resolve before releasing."

--- a/frontend/src/app/(protected)/books/[id]/page.tsx
+++ b/frontend/src/app/(protected)/books/[id]/page.tsx
@@ -6,7 +6,7 @@ import ReviewsList from "./review-list";
 import ReviewsSkeleton from "./reviews-skeleton";
 import { Book } from "@/types";
 import { ApiResponse } from "@/types";
-import { serverSideApiFetch, getBackendUrl } from "@/lib/api-client";
+import { serverSideApiFetch, getBackendUrl, ApiError } from "@/lib/api-client";
 
 export const dynamic = "force-dynamic";
 
@@ -37,6 +37,10 @@ export default async function BookPage({
   const cookieStore = await cookies();
   const accessToken = cookieStore.get("access_token")?.value ?? '';
 
+  if (!accessToken) {
+    redirect('/login');
+  }
+
   if (!id || isNaN(Number(id))) {
     notFound();
   }
@@ -45,7 +49,7 @@ export default async function BookPage({
   try {
     book = await getBookData(id, accessToken);
   } catch (error) {
-    if (error instanceof Error && error.message.includes('401')) {
+    if (error instanceof ApiError && error.status === 401) {
       redirect('/login');
     }
     throw error;

--- a/frontend/src/app/(protected)/books/[id]/review-list.tsx
+++ b/frontend/src/app/(protected)/books/[id]/review-list.tsx
@@ -3,7 +3,8 @@ import { ApiResponse } from "@/types";
 import ReviewActions from "./review-actions";
 import { Star, User } from "lucide-react";
 import Image from "next/image";
-import { serverSideApiFetch, getBackendUrl } from "@/lib/api-client";
+import { redirect } from "next/navigation";
+import { serverSideApiFetch, getBackendUrl, ApiError } from "@/lib/api-client";
 
 const renderStars = (rate: number) => {
   return Array.from({ length: 5 }, (_, i) => (
@@ -28,11 +29,20 @@ type ReviewsListProps = {
 };
 
 export default async function ReviewsList({ bookId, token }: ReviewsListProps) {
-  const reviewsData = (await serverSideApiFetch(
-    `${getBackendUrl()}/reviews/book/${bookId}`,
-    token,
-    { cache: 'no-store' },
-  )) as ApiResponse<Review[]> | null;
+  let reviewsData: ApiResponse<Review[]> | null = null;
+
+  try {
+    reviewsData = (await serverSideApiFetch(
+      `${getBackendUrl()}/reviews/book/${bookId}`,
+      token,
+      { cache: 'no-store' },
+    )) as ApiResponse<Review[]> | null;
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 401) {
+      redirect('/login');
+    }
+    throw error;
+  }
 
   const reviews: Review[] = reviewsData?.data ?? [];
 

--- a/frontend/src/app/(protected)/books/books-skeleton.tsx
+++ b/frontend/src/app/(protected)/books/books-skeleton.tsx
@@ -1,0 +1,32 @@
+export default function BooksSkeleton() {
+  return (
+    <>
+      <div className="h-7 w-48 bg-blue-700 rounded animate-pulse mb-6" />
+      <ul className="space-y-4">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <li
+            key={i}
+            className="bg-blue-900 border border-blue-600 p-4 rounded-lg shadow-md"
+          >
+            <div className="flex">
+              <div className="w-24 h-32 bg-blue-700 rounded mr-4 shrink-0 animate-pulse" />
+              <div className="flex-1">
+                <div className="h-5 w-3/4 bg-blue-700 rounded animate-pulse" />
+                <div className="h-3 w-1/2 bg-blue-700 rounded animate-pulse mt-2" />
+                <div className="mt-2">
+                  <div className="h-3 w-full bg-blue-700 rounded animate-pulse mb-2" />
+                  <div className="h-3 w-full bg-blue-700 rounded animate-pulse mb-2" />
+                  <div className="h-3 w-4/5 bg-blue-700 rounded animate-pulse" />
+                </div>
+                <div className="mt-2 flex gap-2">
+                  <div className="h-3 w-16 bg-blue-700 rounded animate-pulse" />
+                  <div className="h-3 w-24 bg-blue-700 rounded animate-pulse" />
+                </div>
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}

--- a/frontend/src/app/(protected)/books/external/[externalId]/page.tsx
+++ b/frontend/src/app/(protected)/books/external/[externalId]/page.tsx
@@ -3,7 +3,7 @@
 import { cookies } from "next/headers";
 import { notFound, redirect } from "next/navigation";
 import { ApiResponse } from "@/types";
-import { getBackendUrl, serverSideApiFetch } from "@/lib/api-client";
+import { getBackendUrl, serverSideApiFetch, ApiError } from "@/lib/api-client";
 import Image from "next/image";
 import { Star, User } from "lucide-react";
 import { ExternalBook, UserBook, Review } from "@/types";
@@ -80,28 +80,24 @@ async function getExternalBookData(
   externalId: string,
   accessToken: string,
 ): Promise<{ book: ExternalBook; userBook: UserBook; reviews: Review[] }> {
-  try {
-    const response = (await serverSideApiFetch(
-      `${getBackendUrl()}/books/external/${externalId}`,
-      accessToken,
-      {
-        cache: 'no-store',
-      },
-    )) as ApiResponse<{
-      book: ExternalBook;
-      userBook: UserBook;
-      reviews: Review[];
-    }>;
-    const data = response.data;
+  const response = (await serverSideApiFetch(
+    `${getBackendUrl()}/books/external/${externalId}`,
+    accessToken,
+    {
+      cache: 'no-store',
+    },
+  )) as ApiResponse<{
+    book: ExternalBook;
+    userBook: UserBook;
+    reviews: Review[];
+  }>;
+  const data = response.data;
 
-    if (!data || !data.book || !data.book.external_id) {
-      throw new Error("Invalid book data received");
-    }
-
-    return data;
-  } catch (error) {
-    throw error;
+  if (!data || !data.book || !data.book.external_id) {
+    throw new Error("Invalid book data received");
   }
+
+  return data;
 }
 
 type Props = {
@@ -113,13 +109,17 @@ export default async function ExternalBookPage({ params }: Props) {
   const cookieStore = await cookies();
   const accessToken = cookieStore.get("access_token")?.value ?? '';
 
+  if (!accessToken) {
+    redirect('/login');
+  }
+
   let book: ExternalBook;
   let userBook: UserBook;
   let reviews: Review[];
   try {
     ({ book, userBook, reviews } = await getExternalBookData(externalId, accessToken));
   } catch (error) {
-    if (error instanceof Error && error.message.includes('401')) {
+    if (error instanceof ApiError && error.status === 401) {
       redirect('/login');
     }
     throw error;

--- a/frontend/src/app/(protected)/books/page.tsx
+++ b/frontend/src/app/(protected)/books/page.tsx
@@ -4,7 +4,8 @@ import Link from "next/link";
 import Image from "next/image";
 import { useEffect } from "react";
 import { useSearchBookStore } from "@/store/useSearchBookStore";
-import { AlertTriangle, Book, Loader2 } from "lucide-react";
+import { AlertTriangle, Book } from "lucide-react";
+import BooksSkeleton from "./books-skeleton";
 import { Pagination } from "@/components/pagination";
 
 export default function BooksPage() {
@@ -36,14 +37,11 @@ export default function BooksPage() {
     fetchPopularBooksPaginated(page);
   };
 
-  // Show loading spinner when search is in progress
+  // Show skeleton cards when loading is in progress
   if (isLoading) {
     return (
-      <div className="p-6 bg-[#0a1128] text-white min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <Loader2 className="w-12 h-12 text-blue-400 animate-spin mx-auto mb-4" />
-          <p className="text-blue-200 text-lg">Searching for books...</p>
-        </div>
+      <div className="p-6 bg-[#0a1128] text-white min-h-screen">
+        <BooksSkeleton />
       </div>
     );
   }

--- a/frontend/src/app/(protected)/library/page.tsx
+++ b/frontend/src/app/(protected)/library/page.tsx
@@ -2,7 +2,7 @@
 
 import UserBookActions from "@/components/user-book-actions";
 import { BookStatus, UserBook, PaginatedResponse, PaginationMetadata } from "@/types";
-import { getBackendUrl, serverSideApiFetch } from "@/lib/api-client";
+import { getBackendUrl, serverSideApiFetch, ApiError } from "@/lib/api-client";
 import { convertBookToExternalBook } from "@/utils/book";
 import { Metadata } from "next";
 import { redirect } from 'next/navigation';
@@ -69,9 +69,10 @@ export default async function LibraryPage({
       paginationData = data.pagination;
     }
   } catch (error) {
-    if (error instanceof Error && error.message.includes('401')) {
+    if (error instanceof ApiError && error.status === 401) {
       redirect('/login');
     }
+    throw error;
   }
 
   function truncate(text: string, maxLength: number) {

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -1,6 +1,16 @@
 import { handleTokenRefresh } from "./auth";
 import { handleRateLimitResponse } from "./rate-limit-toast";
 
+export class ApiError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+  }
+}
+
 export interface ApiResponse<T> {
   data: T | null;
   status: string;
@@ -306,7 +316,7 @@ export async function serverSideApiFetch(
   }
 
   if (!response.ok) {
-    throw new Error(`API error: ${response.status}`);
+    throw new ApiError(response.status, `HTTP error! status: ${response.status}`);
   }
 
   return response.json();

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,9 +1,32 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
+function isJwtExpired(token: string): boolean {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return false;
+
+    // Base64url → base64 → decode
+    const payload = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const padded = payload + '='.repeat((4 - payload.length % 4) % 4);
+    const decoded = JSON.parse(atob(padded)) as { exp?: number };
+
+    if (typeof decoded.exp !== 'number') return false;
+    return decoded.exp < Date.now() / 1000;
+  } catch {
+    // If decoding fails, let the backend decide
+    return false;
+  }
+}
+
 export function middleware(request: NextRequest) {
-  const token = request.cookies.get('access_token');
-  if (!token) return NextResponse.redirect(new URL('/login', request.url));
+  const tokenCookie = request.cookies.get('access_token');
+  if (!tokenCookie) return NextResponse.redirect(new URL('/login', request.url));
+
+  if (isJwtExpired(tokenCookie.value)) {
+    return NextResponse.redirect(new URL('/login', request.url));
+  }
+
   return NextResponse.next();
 }
 


### PR DESCRIPTION
## What's included

### Frontend
- **Auth redirect hardening** — `/library`, `/books/[id]`, `/books/external/[externalId]`, and `review-list` now redirect to `/login` on empty token or 401 response instead of silently rendering empty state
- **`ApiError` class** — `serverSideApiFetch` throws structured `ApiError` with `.status` field; all protected pages use `instanceof` check instead of string matching
- **Middleware JWT expiry** — middleware now decodes and validates JWT `exp` claim (not just cookie existence), redirecting expired sessions at the edge
- **Books skeleton loading** — books page replaces full-page spinner with skeleton cards during data fetch

## PRs merged
- #181 fix(frontend): redirect to /login on 401 instead of silent empty state
- #180 feat(frontend): replace books page spinner with skeleton cards

## Checklist
- [x] All CI checks pass on `development`
- [x] No `.env` or secrets committed
- [x] Migrations included if schema changed