### PR TITLE
feat(frontend): lazy-load BookRecommendationGraph via next/dynamic

### DIFF
--- a/frontend/src/app/(protected)/recommendation/page.tsx
+++ b/frontend/src/app/(protected)/recommendation/page.tsx
@@ -1,10 +1,16 @@
 'use client';
 
 import { useEffect, useState } from "react";
+import dynamic from "next/dynamic";
 import { apiFetchFull } from "@/lib/api-client";
 import { useAuthStore } from "@/store/useAuthStore";
 import Link from "next/link";
-import BookRecommendationGraph from '@/components/features/BookRecommendationGraph';
+import GraphSkeleton from "@/components/features/graph-skeleton";
+
+const BookRecommendationGraph = dynamic(
+  () => import("@/components/features/BookRecommendationGraph"),
+  { ssr: false, loading: () => <GraphSkeleton /> }
+);
 
 interface BookRecommendation {
   external_id: string;
@@ -117,8 +123,8 @@ export default function RecommendationPage() {
         } else if (rec?.message) {
           setUnavailableMessage(rec.message);
         }
-      } catch (error) {
-        console.error("❌ Error fetching recommendations:", error);
+      } catch {
+        // silent — UI already shows unavailable state
       } finally {
         setLoadingRecommendations(false);
       }

--- a/frontend/src/components/features/graph-skeleton.tsx
+++ b/frontend/src/components/features/graph-skeleton.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export default function GraphSkeleton(): React.ReactElement {
+  return (
+    <div className="w-full">
+      <div
+        className="relative w-full animate-pulse rounded-xl border border-[#3F8EF3]"
+        style={{ height: '70vh', minHeight: 400, background: '#0a1128' }}
+      >
+        <div className="absolute inset-0 flex items-center justify-center">
+          <div className="flex flex-col items-center gap-4">
+            <div className="h-12 w-12 rounded-full bg-[#0e2050]" />
+            <div className="h-3 w-48 rounded bg-[#0e2050]" />
+          </div>
+        </div>
+        <div className="absolute bottom-4 left-4 flex flex-col gap-2">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="h-8 w-8 rounded bg-[#0e2050]" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Converts the static import of `BookRecommendationGraph` to `next/dynamic` with `ssr: false`, deferring the load of `@xyflow/react` (~150KB gzipped) until the recommendation graph is actually rendered
- Adds `GraphSkeleton` (`frontend/src/components/features/graph-skeleton.tsx`) as the loading fallback — animated pulse placeholder that matches the graph container dimensions
- Removes stale `console.error` from the recommendation fetch catch block; the UI already surfaces the unavailable state

Closes #138.

## Test plan

- [x] Visit `/recommendation` — page loads without the xyflow bundle in the initial network waterfall
- [x] Once recommendations load, the graph renders correctly with nodes and edges
- [x] While the graph is loading, `GraphSkeleton` pulse animation is visible
- [x] No TypeScript or ESLint errors (`npm run lint` clean)
- [x] `next build` completes without prerender or SSR errors
- [x] No `console.error` fires in the browser console on recommendation fetch failure