### PR TITLE
release: development → master (2026-07-28)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Drop test database
         if: always()
-        run: docker compose exec -T db psql -U postgres -c "DROP DATABASE IF EXISTS fastlibrary_test;"
+        run: docker compose exec -T db psql -U postgres -c "DROP DATABASE IF EXISTS fastlibrary_test;" || true
 
       - name: 🧹 Teardown
         if: always()

--- a/frontend/e2e/admin/invalid-tab.spec.ts
+++ b/frontend/e2e/admin/invalid-tab.spec.ts
@@ -5,14 +5,14 @@ test.describe('Admin dashboard tab validation', () => {
     await page.goto('/admin?tab=hax');
 
     await expect(page.getByText('Invalid tab: hax')).toBeVisible({ timeout: 10000 });
-    await expect(page.getByRole('button', { name: 'Go to dashboard' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Go to dashboard' })).toBeVisible();
   });
 
   test('should reset to default when clicking Go to dashboard', async ({ page }) => {
     await page.goto('/admin?tab=hax');
 
     await expect(page.getByText('Invalid tab: hax')).toBeVisible({ timeout: 10000 });
-    await page.getByRole('button', { name: 'Go to dashboard' }).click();
+    await page.getByRole('link', { name: 'Go to dashboard' }).click();
 
     await expect(page).toHaveURL(/\/admin$/, { timeout: 10000 });
     await expect(page.getByText('Invalid tab: hax')).not.toBeVisible();

--- a/frontend/src/app/(protected)/admin/admin-dashboard.tsx
+++ b/frontend/src/app/(protected)/admin/admin-dashboard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Suspense, useEffect, useState } from "react";
+import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useAuthStore } from "@/store/useAuthStore";
 import { getStats } from "@/services/adminService";
@@ -79,12 +80,12 @@ function AdminDashboardContent() {
           <p className="text-orange-300 text-sm font-medium">
             Invalid tab: {rawTab}
           </p>
-          <button
-            onClick={() => router.push("/admin")}
+          <Link
+            href="/admin"
             className="text-blue-400 hover:text-white text-sm underline transition-colors"
           >
             Go to dashboard
-          </button>
+          </Link>
         </div>
       )}
       {!isInvalidTab && activeTab === "users" && <AdminUsersTable />}

--- a/frontend/src/app/(protected)/books/external/[externalId]/page.tsx
+++ b/frontend/src/app/(protected)/books/external/[externalId]/page.tsx
@@ -5,6 +5,7 @@ import { notFound, redirect } from "next/navigation";
 import { ApiResponse } from "@/types";
 import { getBackendUrl, serverSideApiFetch, ApiError } from "@/lib/api-client";
 import Image from "next/image";
+import { BOOK_COVER_BLUR_DATA_URL } from "@/lib/image-utils";
 import { Star, User } from "lucide-react";
 import { ExternalBook, UserBook, Review } from "@/types";
 import ExternalBookPageClient from "@/components/external-book-client";
@@ -133,13 +134,18 @@ export default async function ExternalBookPage({ params }: Props) {
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           <div className="md:col-span-1">
             {book.thumbnail && (
-              <Image
-                src={book.thumbnail.replace(/^http:\/\//, 'https://')}
-                alt={book.title}
-                width={80}
-                height={80}
-                className="w-full rounded-md shadow-md"
-              />
+              <div className="relative w-24 h-32 rounded-md shadow-md overflow-hidden">
+                <Image
+                  src={book.thumbnail.replace(/^http:\/\//, 'https://')}
+                  alt={book.title}
+                  fill
+                  sizes="96px"
+                  priority={true}
+                  placeholder="blur"
+                  blurDataURL={BOOK_COVER_BLUR_DATA_URL}
+                  style={{ objectFit: "cover" }}
+                />
+              </div>
             )}
           </div>
 

--- a/frontend/src/app/(protected)/books/page.tsx
+++ b/frontend/src/app/(protected)/books/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import { useEffect } from "react";
+import { BOOK_COVER_BLUR_DATA_URL } from "@/lib/image-utils";
 import { useSearchBookStore } from "@/store/useSearchBookStore";
 import { AlertTriangle, Book } from "lucide-react";
 import BooksSkeleton from "./books-skeleton";
@@ -53,7 +54,7 @@ export default function BooksPage() {
         <div className="mb-8">
           <h2 className="text-2xl font-bold text-blue-400 mb-6">Popular Books</h2>
           <ul className="space-y-4">
-            {popularBooks.map((book) => (
+            {popularBooks.map((book, index) => (
               <li
                 key={book.external_id}
                 className="bg-blue-900 border border-blue-600 p-4 rounded-lg shadow-md transition duration-300 hover:shadow-xl hover:bg-blue-800"
@@ -67,9 +68,12 @@ export default function BooksPage() {
                       <Image
                         src={book?.thumbnail}
                         alt={book.title}
-                        width={80}
-                        height={80}
+                        width={96}
+                        height={128}
                         className="w-24 h-32 object-cover rounded mr-4"
+                        priority={index === 0}
+                        placeholder="blur"
+                        blurDataURL={BOOK_COVER_BLUR_DATA_URL}
                       />
                     )}
                     <div>
@@ -135,9 +139,11 @@ export default function BooksPage() {
                         <Image
                           src={book?.thumbnail}
                           alt={book.title}
-                          width={80}
-                          height={80}
+                          width={96}
+                          height={128}
                           className="w-24 h-32 object-cover rounded mr-4"
+                          placeholder="blur"
+                          blurDataURL={BOOK_COVER_BLUR_DATA_URL}
                         />
                       )}
                       <div>

--- a/frontend/src/app/(protected)/library/page.tsx
+++ b/frontend/src/app/(protected)/library/page.tsx
@@ -8,6 +8,7 @@ import { Metadata } from "next";
 import { redirect } from 'next/navigation';
 import { cookies } from "next/headers";
 import Image from "next/image";
+import { BOOK_COVER_BLUR_DATA_URL } from "@/lib/image-utils";
 import Link from "next/link";
 import { Suspense } from "react";
 import LibraryPagination from "@/components/library-pagination";
@@ -136,8 +137,10 @@ export default async function LibraryPage({
                       alt={`Cover of ${book.title}`}
                       fill
                       style={{ objectFit: "cover" }}
-                      sizes="96px 144px"
+                      sizes="96px"
                       priority={false}
+                      placeholder="blur"
+                      blurDataURL={BOOK_COVER_BLUR_DATA_URL}
                     />
                   </div>
                 ) : (

--- a/frontend/src/hooks/useBooks.ts
+++ b/frontend/src/hooks/useBooks.ts
@@ -30,17 +30,19 @@ export const useBooks = (params: BookSearchParams = {}) => {
         setBooks(response.data);
         setPagination(response.pagination);
       }
-    } catch (err) {
+    } catch (_err) {
       setError('Failed to fetch books');
-      console.error('Error fetching books:', err);
     } finally {
       setLoading(false);
     }
   }, []);
 
+  const { q, page, page_size, author, genre, language } = params;
+
   useEffect(() => {
     fetchBooks(params);
-  }, [fetchBooks, params]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchBooks, q, page, page_size, author, genre, language]);
 
   return {
     books,

--- a/frontend/src/lib/image-utils.ts
+++ b/frontend/src/lib/image-utils.ts
@@ -1,0 +1,4 @@
+// Shared 1x1 gray GIF used as a blur placeholder for book cover images.
+// Prevents layout shift while the real image loads.
+export const BOOK_COVER_BLUR_DATA_URL =
+  "data:image/gif;base64,R0lGODlhAQABAIAAAMLCwgAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==";


### PR DESCRIPTION
## What's included

### Frontend
- Fix `useBooks` hook infinite refetch loop — destructure `BookSearchParams` fields into primitive `useEffect` deps so the effect only re-runs when values change, not on every object allocation (closes #152)
- Fix admin dashboard invalid-tab navigation — replace `router.push` with `<Link>` so navigation works before full React hydration; update E2E selectors accordingly
- Fix Next.js `<Image>` sizing and add blur placeholders on book cover images (closes #139)

### CI/CD
- Make "Drop test database" step non-fatal (`|| true`) — step runs `if: always()` so it fired even when the `db` container never started; volumes are cleaned up by Teardown regardless

## PRs merged
- #186 fix(frontend): correct Next.js Image sizing and add blur placeholders
- #187 fix(frontend/e2e/ci): useBooks infinite refetch + admin tab navigation + CI db teardown

## Checklist
- [x] All CI checks pass on `development`
- [x] No `.env` or secrets committed
- [x] Migrations included if schema changed